### PR TITLE
Use Sequelize BOOLEAN for boolean fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "babel-node src/index.js",
     "build": "babel src --out-dir dist",
     "prepublish": "npm run build",
+    "prepare": "npm run build",
     "test": "jest",
     "test:watch": "jest --watch"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "start": "babel-node src/index.js",
     "build": "babel src --out-dir dist",
-    "prepublish": "npm run build",
     "prepare": "npm run build",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/src/builders/definitions.js
+++ b/src/builders/definitions.js
@@ -40,7 +40,7 @@ export default columns => {
       field: column.name,
       allowNull: column.notnull === 0 || column.dflt_value !== null,
       defaultValue: column.dflt_value,
-      autoIncrement: column.type === 'INTEGER' && column.pk === 1,
+      autoIncrement: column.type === 'integer' && column.pk === 1,
     };
 
     return acc;

--- a/src/builders/definitions.js
+++ b/src/builders/definitions.js
@@ -1,4 +1,4 @@
-import { TEXT, INTEGER, REAL, NUMERIC, BLOB } from 'sequelize';
+import { TEXT, INTEGER, REAL, NUMERIC, BLOB, BOOLEAN } from 'sequelize';
 import { formatFieldName } from '../utils';
 
 const transformColumnToType = column => {
@@ -19,11 +19,14 @@ const transformColumnToType = column => {
   if (
     c.includes('decimal') ||
     c.includes('numeric') ||
-    c === 'boolean' ||
     c === 'date' ||
     c === 'datetime'
   ) {
     return NUMERIC;
+  }
+
+  if (c === 'boolean') {
+    return BOOLEAN;
   }
 
   return BLOB;


### PR DESCRIPTION
SQLite boolean fields are currently being typed as Sequelize's NUMERIC type (https://github.com/bradleyboy/tuql/blob/master/src/builders/definitions.js#L22) but they end up as a String type on the GraphQL API.

I'm using Sequelize's BOOLEAN instead and it's working as expected.