### PR TITLE
Fix a bug with sqllite default values and inserts

### DIFF
--- a/src/builders/schema.js
+++ b/src/builders/schema.js
@@ -184,7 +184,13 @@ const build = db => {
         type,
         args: makeCreateArgs(model),
         resolve: async (obj, values, info) => {
-          const thing = await model.create(values);
+          const options = {
+            // By default sequelize will insert all columns which can cause a
+            // bug where default values, that use functions, defined at the
+            // database layer don't get populated correctly.
+            fields: Object.keys(values),
+          };
+          const thing = await model.create(values, options);
           return thing;
         },
       };


### PR DESCRIPTION
I found a bug where sequelize was incorrectly inserting a raw string when it should have been respecting the default defined at the database column level. This PR fixes it by reducing the `fields` that sequelize inserts to to only those defined on the `values`.

Here's a repro. Make a table like this:
```
CREATE TABLE accounts (
  "id"                  TEXT PRIMARY KEY,
  "name"                TEXT NOT NULL,
  "created"             TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ')),
) WITHOUT ROWID;
```
And try to insert just a record with just a "name". You'll end up with the literal `strftime('%Y-%m-%dT%H:%M:%SZ')` for the `created` column.
